### PR TITLE
Implement datasets CRUD over elastic

### DIFF
--- a/.swagger-codegen-ignore
+++ b/.swagger-codegen-ignore
@@ -5,7 +5,9 @@ README.md
 .dockerignore
 .gitignore
 tox.ini
+test-requirements.txt
 
 # These have been hand-modified, no need to regenerate.
 **/*_controller.py
 **/__main__.py
+**/test/__init__.py

--- a/README.md
+++ b/README.md
@@ -23,6 +23,20 @@ pip install tox
 tox
 ```
 
+### Useful flags
+
+Support breakpointing with pdb:
+
+```
+tox -- -s
+```
+
+Run a subset of tests:
+
+```
+tox -- -s data_index/test/test_datasets_controller.py:TestDatasetsController
+```
+
 ## Swagger codegen
 
 ```

--- a/data_index/__main__.py
+++ b/data_index/__main__.py
@@ -1,23 +1,26 @@
 #!/usr/bin/env python
 
+import argparse
 import connexion
 from .encoder import JSONEncoder
 
 app = connexion.App(__name__, specification_dir='./swagger/')
 app.app.json_encoder = JSONEncoder
-app.add_api(
-    'swagger.yaml',
-    arguments={
-        'title':
-        'API for indexing curated datasets with user-defined labels, and searching that index.  Where possible this API follows [Google Cloud API design guidelines]( https://cloud.google.com/apis/design/), including the convention of using relative resource names to refer to resources. For example, an Individual may be addressed by `datasets/x/individuals/y`;, where the entirety is a resource name and `y`; is the resource ID.'
-    })
-
+app.add_api('swagger.yaml')
 
 if __name__ == '__main__':
-  parser = argparse.ArgumentParser()
-  parser.add_argument('--port', type=int, default=9190)
-  parser.add_argument('--index_addr', type=str, required=True)
-  args = parser.parse_args()
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        '--port',
+        type=int,
+        default=9190,
+        help='The port on which to serve HTTP requests')
+    parser.add_argument(
+        '--index_addr',
+        type=str,
+        required=True,
+        help='The base URL address for the backend ElasticSearch index service')
+    args = parser.parse_args()
 
-  app.app.config['INDEX_ADDR'] = args.index_addr
-  app.run(host='0.0.0.0', port=args.port)
+    app.app.config['INDEX_ADDR'] = args.index_addr
+    app.run(host='0.0.0.0', port=args.port)

--- a/data_index/controllers/datasets_controller.py
+++ b/data_index/controllers/datasets_controller.py
@@ -1,11 +1,60 @@
 import connexion
+import errors
+import requests
 from data_index.models.dataset import Dataset
 from data_index.models.list_datasets_response import ListDatasetsResponse
 from datetime import date, datetime
 from typing import List, Dict
 from six import iteritems
-from werkzeug.exceptions import NotImplemented
-from ..util import deserialize_date, deserialize_datetime
+from data_index import elastic
+from data_index.models.dataset import Dataset
+from data_index.models.list_datasets_response import ListDatasetsResponse
+from data_index.util import deserialize_date, deserialize_datetime
+from werkzeug.exceptions import BadRequest, Conflict, InternalServerError, NotFound, NotImplemented
+
+
+def split_ds_name(ds_name):
+    """Takes a full dataset id string and returns the unique ID.
+
+    >>> split_ds_name('datasets/abc123')
+    'abc123'
+
+    Args:
+      ds_name: (string) full resource name of a dataset, e.g. 'datasets/abc123'
+
+    Returns:
+      (string) the dataset resource id, e.g. 'abc123'
+    """
+    parts = ds_name.split('/')
+    if len(parts) != 2 or parts[0] != 'datasets':
+        raise BadRequest('malformed dataset name "{}"'.format(ds_name))
+    return parts[1]
+
+
+def doc_to_dataset(doc):
+    """Converts an ElasticSearch document dict to a Dataset model.
+
+    Args:
+      doc: (dict) an ElasticSearch document representation of a dataset
+
+    Returns:
+      (data_index.models.dataset.Dataset) a dataset model instance
+    """
+    return Dataset(name='datasets/' + doc['_id'])
+
+
+def dataset_to_doc(dataset):
+    """Converts a Dataset model to an ElasticSearch document dict.
+
+    Args:
+      dataset: (data_index.models.dataset.Dataset) a dataset model instance
+
+    Returns:
+      (dict) an ElasticSearch document representation of the dataset
+    """
+    # Note: a dataset document is currently empty, future extensions to the
+    # dataset API resource will be stored here.
+    return {}
 
 
 def list_datasets(pageSize=64, pageToken=None):
@@ -34,11 +83,70 @@ def create_dataset(body):
       body: the dataset JSON
 
     Returns:
-      a dictionary representing a Dataset
+      the newly created Dataset
     """
-    if connexion.request.is_json:
-        body = Dataset.from_dict(connexion.request.get_json())
-    raise NotImplemented()
+    if not connexion.request.is_json:
+        raise BadRequest('got unexpected non-JSON payload')
+    dataset = Dataset.from_dict(body)
+    if not dataset or not dataset.name:
+        raise BadRequest('missing required dataset.name from request')
+
+    ds_id = split_ds_name(dataset.name)
+
+    # Each dataset has two associated indices, which together form a
+    # bidirectional mapping of individual <-> data pointer using Elastic's
+    # parent-child document semantics. Allow these indices to exist already, in
+    # the event that a previous create_dataset() was partially successful.
+    def raise_for_index_create_status(r):
+        if r.status_code != requests.codes.ok and (
+                elastic.error_type(r.json()) != elastic.INDEX_ALREADY_EXISTS):
+            r.raise_for_status()
+
+    r = requests.put(
+        elastic.by_ppl_index(ds_id),
+        json={
+            'mappings': {
+                'individuals': {},
+                'data': {
+                    '_parent': {
+                        'type': 'individuals',
+                    },
+                },
+            },
+        },
+        headers=elastic.REQ_HEADERS)
+    raise_for_index_create_status(r)
+    r = requests.put(
+        elastic.by_data_index(ds_id),
+        json={
+            'mappings': {
+                'data': {},
+                'individuals': {
+                    '_parent': {
+                        'type': 'data',
+                    },
+                },
+            },
+        },
+        headers=elastic.REQ_HEADERS)
+    raise_for_index_create_status(r)
+
+    # Create the dataset metadata doc last to mark successful creation.
+    r = requests.put(
+        elastic.ds_index_path(ds_id),
+        params={
+            'op_type': 'create',
+            # Wait for the document to be indexed. Dataset operations are low
+            # throughput, so this performance tradeoff is acceptable.
+            'refresh': 'true',
+        },
+        json=dataset_to_doc(dataset),
+        headers=elastic.REQ_HEADERS)
+    if r.status_code == requests.codes.conflict:
+        raise Conflict('dataset "{}" already exists'.format(dataset.name))
+    r.raise_for_status()
+
+    return get_dataset(ds_id)
 
 
 def get_dataset(datasetId):
@@ -49,9 +157,13 @@ def get_dataset(datasetId):
       datasetId: the dataset to retrieve
 
     Returns:
-      a dictionary representation of a Dataset
+      the requested Dataset
     """
-    raise NotImplemented()
+    r = requests.get(elastic.ds_index_path(datasetId))
+    if r.status_code == requests.codes.not_found:
+        raise errors.DatasetNotFound(datasetId)
+    r.raise_for_status()
+    return doc_to_dataset(r.json())
 
 
 def update_dataset(datasetId, body):
@@ -63,11 +175,35 @@ def update_dataset(datasetId, body):
       body: JSON representation of the updated Dataset
 
     Returns:
-      a JSON representation of the updated Dataset
+      the updated Dataset
     """
-    if connexion.request.is_json:
-        body = Dataset.from_dict(connexion.request.get_json())
-    raise NotImplemented()
+    if not connexion.request.is_json:
+        raise InternalServerError('got unexpected non-JSON payload')
+    dataset = Dataset.from_dict(body)
+    if dataset.name:
+        ds_id = split_ds_name(dataset.name)
+        if ds_id != datasetId:
+            raise BadRequest(
+                'URL dataset name "datasets/{}" and dataset.name "{}" must agree'.
+                format(datasetId, dataset.name))
+    else:
+        dataset.name = 'datasets/' + datasetId
+
+    # Raises an error if the dataset is not found.
+    get_dataset(ds_id)
+
+    # For now, we only accept full replacement updates.
+    requests.put(
+        elastic.ds_index_path(ds_id),
+        params={
+            # Wait for the document to be indexed. Dataset operations are low
+            # throughput, so this performance tradeoff is acceptable.
+            'refresh': 'true',
+        },
+        json=dataset_to_doc(dataset),
+        headers=elastic.REQ_HEADERS).raise_for_status()
+
+    return get_dataset(ds_id)
 
 
 def delete_dataset(datasetId):
@@ -77,4 +213,27 @@ def delete_dataset(datasetId):
     Args:
       datasetId: the dataset to delete
     """
-    raise NotImplemented()
+    responses = []
+    # We cannot apply these deletions in a transaction, so we must tolerate
+    # failures between any of the following mutations. Delete the dataset
+    # metadata document first to indicate to the rest of the system that the
+    # dataset is no longer active.
+    for path in [
+            elastic.ds_index_path(datasetId),
+            elastic.by_ppl_index(datasetId),
+            elastic.by_data_index(datasetId)
+    ]:
+        r = requests.delete(path)
+        responses.append(r)
+
+    # This method should be retryable, even if it fails half-way through. To
+    # that end, only return a 404 if we've previously deleted all associated
+    # indices for the dataset.
+    if all([r.status_code == requests.codes.not_found for r in responses]):
+        raise errors.DatasetNotFound(datasetId)
+
+    # If a deletion failed for any other reason, raise an internal error.
+    for r in responses:
+        if r.status_code != requests.codes.not_found:
+            # Only raises an exception for non-2XXs.
+            r.raise_for_status()

--- a/data_index/controllers/errors.py
+++ b/data_index/controllers/errors.py
@@ -1,0 +1,5 @@
+from werkzeug.exceptions import NotFound
+
+class DatasetNotFound(NotFound):
+  def __init__(self, dataset_id, **kwargs):
+    NotFound.__init__(self, '"datasets/{}" not found'.format(dataset_id), **kwargs)

--- a/data_index/elastic.py
+++ b/data_index/elastic.py
@@ -1,0 +1,30 @@
+from flask import current_app
+
+
+REQ_HEADERS = {'content-type': 'application/json'}
+
+INDEX_ALREADY_EXISTS = 'index_already_exists_exception'
+
+
+def error_type(json_resp):
+  return json_resp.get('error', {}).get('type', '')
+
+
+def index_addr():
+  return current_app.config['INDEX_ADDR']
+
+
+def ds_index_type():
+  return index_addr() + '/cdr/datasets'
+
+
+def ds_index_path(ds_id):
+  return ds_index_type() + '/' + ds_id
+
+
+def by_ppl_index(ds_id):
+  return index_addr() + '/by-individual:' + ds_id
+
+
+def by_data_index(ds_id):
+  return index_addr() + '/by-data:' + ds_id

--- a/data_index/test/__init__.py
+++ b/data_index/test/__init__.py
@@ -1,14 +1,49 @@
+from data_index.models.dataset import Dataset
 from flask_testing import TestCase
 from ..encoder import JSONEncoder
+from flask import json
 import connexion
+import fake_elastic
+import httpretty
 import logging
 
 
 class BaseTestCase(TestCase):
+    INDEX_ADDR = 'http://localhost:123'
 
     def create_app(self):
         logging.getLogger('connexion.operation').setLevel('ERROR')
         app = connexion.App(__name__, specification_dir='../swagger/')
         app.app.json_encoder = JSONEncoder
         app.add_api('swagger.yaml')
+        app.app.config.update({'INDEX_ADDR': BaseTestCase.INDEX_ADDR})
         return app.app
+
+    def setUp(self):
+        super(BaseTestCase, self).setUp()
+        httpretty.enable()
+        fake_elastic.register_httpretty(BaseTestCase.INDEX_ADDR,
+                                        fake_elastic.FakeElastic())
+
+    def tearDown(self):
+        httpretty.disable()
+        httpretty.reset()
+        super(BaseTestCase, self).tearDown()
+
+    def must_create_dataset(self, ds):
+        resp = self.client.open(
+            '/v1/datasets',
+            method='POST',
+            data=json.dumps(ds),
+            content_type='application/json')
+        self.assertStatus(resp, 200)
+
+    def must_get_dataset(self, name, desc=None):
+        resp = self.client.open('/v1/' + name, method='GET')
+        self.assertStatus(resp, 200, desc)
+        return Dataset.from_dict(resp.json)
+
+    def assertStatus(self, response, want, desc=None):
+        if not desc:
+            desc = 'Response body is : ' + response.data.decode('utf-8')
+        super(BaseTestCase, self).assertStatus(response, want, desc)

--- a/data_index/test/fake_elastic.py
+++ b/data_index/test/fake_elastic.py
@@ -1,0 +1,93 @@
+from data_index import elastic
+import httpretty
+import json
+import re
+
+
+class FakeElastic:
+    """Fake in-memory Elastic server with limited functionality."""
+
+    def __init__(self):
+      # Index name (str) -> type (str) -> id (str) -> document (dict)
+      self.indices = {}
+
+
+    def put_index(self, name):
+        if name in self.indices:
+            return (400, {}, json.dumps({
+                'error': {
+                    'type': elastic.INDEX_ALREADY_EXISTS
+                }
+            }))
+        self.indices[name] = {}
+        return (200, {}, '')
+
+
+    def delete_index(self, name):
+        if name not in self.indices:
+            return (404, {}, '')
+        del self.indices[name]
+        return (200, {}, '')
+
+
+    def put_document(self, index_name, doc_type, doc_id, doc, query_params):
+        if index_name not in self.indices:
+            # Simulate Elastic's lazy index creation.
+            self.put_index(index_name)
+        index = self.indices[index_name]
+        if doc_type not in index:
+            index[doc_type] = {}
+        doc = doc.copy()
+        doc['_id'] = doc_id
+        if doc_id in index[doc_type] and (
+            'op_type' in query_params and query_params['op_type'] == ['create']):
+            return (409, {}, json.dumps({}))
+
+        index[doc_type][doc_id] = doc
+        return (200, {}, json.dumps({}))
+
+
+    def get_document(self, index_name, doc_type, doc_id):
+        doc = self.indices.get(index_name, {}).get(doc_type, {}).get(doc_id)
+        if not doc:
+            return (404, {}, '')
+        return (200, {}, json.dumps(doc))
+
+
+    def delete_document(self, index_name, doc_type, doc_id):
+        doc = self.indices.get(index_name, {}).get(doc_type, {}).get(doc_id)
+        if not doc:
+            return (404, {}, '')
+        del self.indices[index_name][doc_type][doc_id]
+        return (200, {}, json.dumps(doc))
+
+
+def register_httpretty(base_url, fake):
+    # Wrap index methods.
+    index_re = re.compile(base_url + '/[^/?]+(\?.*)?$')
+    def wrap_put_index(request, uri, headers):
+        return fake.put_index(uri[len(base_url + '/'):])
+    httpretty.register_uri(httpretty.PUT, index_re, wrap_put_index)
+
+    def wrap_delete_index(request, uri, headers):
+        return fake.delete_index(uri[len(base_url + '/'):])
+    httpretty.register_uri(httpretty.DELETE, index_re, wrap_delete_index)
+
+    # Wrap document methods.
+    doc_re = re.compile(base_url + '/([^/]+)/([^/]+)/([^/?]+)(\?.*)?$')
+    def wrap_put_document(request, uri, headers):
+        doc = json.loads(request.body)
+        m = doc_re.match(uri)
+        return fake.put_document(m.group(1), m.group(2), m.group(3), doc,
+                                 request.querystring)
+    httpretty.register_uri(httpretty.PUT, doc_re, wrap_put_document)
+
+    def wrap_get_document(request, uri, headers):
+        m = doc_re.match(uri)
+        return fake.get_document(m.group(1), m.group(2), m.group(3))
+    httpretty.register_uri(httpretty.GET, doc_re, wrap_get_document)
+
+    def wrap_delete_document(request, uri, headers):
+        m = doc_re.match(uri)
+        return fake.delete_document(m.group(1), m.group(2), m.group(3))
+    httpretty.register_uri(httpretty.DELETE, doc_re, wrap_delete_document)

--- a/data_index/test/test_datasets_controller.py
+++ b/data_index/test/test_datasets_controller.py
@@ -1,5 +1,8 @@
 from __future__ import absolute_import
 
+import doctest
+import unittest
+from data_index.controllers import datasets_controller
 from data_index.models.dataset import Dataset
 from data_index.models.list_datasets_response import ListDatasetsResponse
 from data_index.test import BaseTestCase
@@ -8,7 +11,7 @@ from flask import json
 
 
 class TestDatasetsController(BaseTestCase):
-    """Datasets integration tests."""
+    """Datasets tests."""
 
     def test_list_datasets(self):
         query_string = [('pageSize', 56), ('pageToken', 'pageToken_example')]
@@ -21,41 +24,90 @@ class TestDatasetsController(BaseTestCase):
                           "Response body is : " + response.data.decode('utf-8'))
 
     def test_create_dataset(self):
-        body = Dataset(name='datasets/foo')
-        response = self.client.open(
+        ds = Dataset(name='datasets/foo')
+        self.must_create_dataset(ds)
+
+        got = self.must_get_dataset(ds.name)
+        self.assertEqual(ds, got)
+
+    def test_create_dataset_duplicate(self):
+        ds = Dataset(name='datasets/foo')
+        self.must_create_dataset(ds)
+
+        resp = self.client.open(
             '/v1/datasets',
             method='POST',
-            data=json.dumps(body),
+            data=json.dumps(ds),
             content_type='application/json')
-        self.assertStatus(response, 501,
-                          "Response body is : " + response.data.decode('utf-8'))
+        self.assertStatus(resp, 409)
 
-    def test_get_dataset(self):
-        response = self.client.open(
-            '/v1/datasets/{datasetId}'.format(datasetId='datasetId_example'),
-            method='GET',
-            content_type='application/json')
-        self.assertStatus(response, 501,
-                          "Response body is : " + response.data.decode('utf-8'))
+    def test_get_dataset_not_found(self):
+        resp = self.client.open('/v1/datasets/foo', method='GET')
+        self.assertStatus(resp, 404)
 
     def test_update_dataset(self):
-        body = Dataset(name='datasets/foo')
-        response = self.client.open(
-            '/v1/datasets/{datasetId}'.format(datasetId='foo'),
+        ds = Dataset(name='datasets/foo')
+        self.must_create_dataset(ds)
+
+        resp = self.client.open(
+            '/v1/' + ds.name,
             method='PUT',
-            data=json.dumps(body),
+            data=json.dumps(ds),
             content_type='application/json')
-        self.assertStatus(response, 501,
-                          "Response body is : " + response.data.decode('utf-8'))
+        self.assertStatus(resp, 200)
+
+    def test_update_dataset_not_found(self):
+        resp = self.client.open(
+            '/v1/datasets/notfound',
+            method='PUT',
+            data=json.dumps({
+                'name': 'datasets/notfound'
+            }),
+            content_type='application/json')
+        self.assertStatus(resp, 404)
+
+    def test_update_dataset_mismatch_names(self):
+        ds = Dataset(name='datasets/foo')
+        self.must_create_dataset(ds)
+
+        resp = self.client.open(
+            '/v1/' + ds.name,
+            method='PUT',
+            data=json.dumps({
+                'name': 'datasets/bar'
+            }),
+            content_type='application/json')
+        self.assertStatus(resp, 400)
 
     def test_delete_dataset(self):
-        response = self.client.open(
-            '/v1/datasets/{datasetId}'.format(datasetId='datasetId_example'),
-            method='DELETE',
-            content_type='application/json')
-        self.assertStatus(response, 501,
-                          "Response body is : " + response.data.decode('utf-8'))
+        ds = Dataset(name='datasets/foo')
+        ds_untouched = Dataset(name='datasets/untouched')
+        self.must_create_dataset(ds)
+        self.must_create_dataset(ds_untouched)
 
+        resp = self.client.open('/v1/' + ds.name, method='DELETE')
+        self.assertStatus(resp, 200)
+        resp = self.client.open('/v1/' + ds.name, method='GET')
+        self.assertStatus(resp, 404)
+        self.must_get_dataset(ds_untouched.name,
+                              "unrelated dataset was deleted")
+
+    def test_delete_dataset_not_found(self):
+        ds_untouched = Dataset(name='datasets/untouched')
+        self.must_create_dataset(ds_untouched)
+
+        resp = self.client.open('/v1/datasets/notfound', method='DELETE')
+        self.assertStatus(resp, 404)
+        self.must_get_dataset(ds_untouched.name,
+                              "unrelated dataset was deleted")
+
+
+class TestExamplesInDocstrings(unittest.TestCase):
+    """Test examples in doc strings."""
+
+    def test_doctest(self):
+        result = doctest.testmod(datasets_controller, report=True)
+        self.assertEqual(0, result.failed)
 
 if __name__ == '__main__':
     import unittest

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,5 +1,6 @@
 flask_testing==0.6.1
 coverage>=4.0.3
+httpretty==0.8.14
 nose>=1.3.7
 pluggy>=0.3.1
 py>=1.4.31

--- a/tox.ini
+++ b/tox.ini
@@ -6,5 +6,5 @@ deps=-r{toxinidir}/requirements.txt
      -r{toxinidir}/test-requirements.txt
 
 commands=
-   nosetests \
+   nosetests --nologcapture \
       []


### PR DESCRIPTION
- ListDatasets is still unsupported.
- Datasets CRUD is implemented.
- Associated individual/dataPointer indices are created alongside the dataset.
- Added a fake in-memory Elastic server layer wired up via `httpretty` for testing.